### PR TITLE
ppcfd: add .h5 converter & remove redundant code of decorator & disable default generation of .npz file

### DIFF
--- a/ppcfd/data/parser/__init__.py
+++ b/ppcfd/data/parser/__init__.py
@@ -14,12 +14,12 @@
 
 
 from ppcfd.data.parser.base_parser import DataParserFactory
-from ppcfd.data.parser.mat2npz import MatTransition
+from ppcfd.data.parser.h5_mat2npz import H5MatTransition
 from ppcfd.data.parser.msh2npz import MshTransition
 
 
 __all__ = [
     "DataParserFactory",
+    "H5MatTransition",
     "MshTransition",
-    "MatTransition",
 ]

--- a/ppcfd/data/parser/base_parser.py
+++ b/ppcfd/data/parser/base_parser.py
@@ -22,7 +22,9 @@ class DataParserMeta(ABCMeta):
     def __init__(cls, name, bases, attrs):
         super().__init__(name, bases, attrs)
         if hasattr(cls, "file_format"):
-            DataParserFactory.register_loader(cls.file_format)(cls)
+            formats = cls.file_format if isinstance(cls.file_format, list) else [cls.file_format]
+            for fmt in formats:
+                DataParserFactory.register_loader(fmt)(cls)
 
 
 class DataParserFactory:

--- a/ppcfd/data/parser/msh2npz.py
+++ b/ppcfd/data/parser/msh2npz.py
@@ -20,7 +20,7 @@ from typing import Optional, Union
 
 import numpy as np
 
-from ppcfd.data.parser.base_parser import BaseTransition, DataParserFactory
+from ppcfd.data.parser.base_parser import BaseTransition
 
 
 class MeshSource(Enum):
@@ -43,14 +43,13 @@ class MeshSource(Enum):
     GENERAL = "general"
 
 
-@DataParserFactory.register_loader("msh")
 class MshTransition(BaseTransition):
     """Transition class for .msh file.
 
     Args:
         file_path (Union[str, Path]): path of .msh file.
         save_path (Optional[str], optional): path of saved .npz file. Defaults to None.
-        save_data (Optional[bool], optional): Whether to save the .npz file. Defaults to True.
+        save_data (Optional[bool], optional): Whether to save the .npz file. Defaults to False.
         source (Optional[Union[MeshSource, str]], optional): source of .msh file such as openfoam. Defaults to MeshSource.AUTO.
     """
 
@@ -62,7 +61,7 @@ class MshTransition(BaseTransition):
         self,
         file_path: Union[str, Path],
         save_path: Optional[Union[str, Path]] = None,
-        save_data: bool = True,
+        save_data: bool = False,
         source: Optional[Union[MeshSource, str]] = MeshSource.AUTO,
         **kwargs,
     ):
@@ -278,16 +277,3 @@ class MshTransition(BaseTransition):
 
     def get_data(self):
         return self.data
-
-
-if __name__ == "__main__":
-    path = "./SAE_BA11.0_DA3.0.msh"
-    # save_path = './SAE_BA11.0_DA3.0.npz'
-    # trans_obj = MshTransition(path, save_path)
-    # trans_obj = MshTransition(path, source='gmsh')
-    trans_obj = MshTransition(path, source="auto")
-    for key, value in trans_obj.data.items():
-        if isinstance(value, np.ndarray):
-            print(f"{key}: shape: {value.shape}")
-        else:
-            print(f"{key}: type: {type(value)}")


### PR DESCRIPTION
Changes:

1. add .h5 conversion code to the original .mat conversion code and modify the .py file name accordingly.
- the reason for this is that, in order to be compatible with the processing of .mat files generated by different versions of MATLAB, the original processing code includes the parsing of .h5 format files (but the suffix is ​​still .mat). If a new h52npz.py file is created, this part of the code will be repeated.

2. remove redundant code of decorator
- the registration code exists in the init of the base class, so there is no need to call the decorator additionally.

3. modify the code to support multiple file `file_format` in a single data transition class.

4. disable default generation of .npz file.